### PR TITLE
Convert static HTML pages to Next.js

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,118 @@
+import { supabase } from '@/utils/supabase';
+import { format } from 'date-fns';
+import { Event as EventIcon } from '@mui/icons-material';
+import {
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Chip,
+  Box,
+  Paper,
+} from '@mui/material';
+
+export const revalidate = 30;
+
+interface EventWithCount {
+  id: string;
+  name: string;
+  description: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  status: string;
+  _count?: {
+    team_rosters: number;
+  };
+}
+
+async function getEvents(): Promise<EventWithCount[]> {
+  const { data: events, error } = await supabase
+    .from('events')
+    .select(`id, name, description, start_date, end_date, status`)
+    .order('start_date', { ascending: false });
+
+  if (error) {
+    console.error('Error fetching events:', error);
+    return [];
+  }
+
+  const eventsWithCounts = await Promise.all(
+    (events || []).map(async (event) => {
+      const { count } = await supabase
+        .from('team_rosters')
+        .select('*', { count: 'exact', head: true })
+        .eq('event_id', event.id);
+
+      return {
+        ...event,
+        _count: { team_rosters: count || 0 },
+      };
+    })
+  );
+
+  return eventsWithCounts;
+}
+
+export default async function EventsPage() {
+  const events = await getEvents();
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold', mb: 3 }}>
+        Events
+      </Typography>
+      <Grid container spacing={3}>
+        {events.length > 0 ? (
+          events.map((event) => (
+            <Grid item xs={12} md={6} lg={4} key={event.id}>
+              <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <CardContent sx={{ flexGrow: 1 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                    <EventIcon color="primary" />
+                    <Chip
+                      label={event.status}
+                      size="small"
+                      color={event.status === 'active' ? 'success' : event.status === 'upcoming' ? 'warning' : 'default'}
+                    />
+                  </Box>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 600, mb: 1 }}>
+                    {event.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    {event.description || 'No description available'}
+                  </Typography>
+                  {event.start_date && (
+                    <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                      Start: {format(new Date(event.start_date), 'MMM dd, yyyy')}
+                    </Typography>
+                  )}
+                  {event.end_date && (
+                    <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 2 }}>
+                      End: {format(new Date(event.end_date), 'MMM dd, yyyy')}
+                    </Typography>
+                  )}
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {event._count?.team_rosters || 0} teams
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))
+        ) : (
+          <Grid item xs={12}>
+            <Paper sx={{ p: 6, textAlign: 'center' }}>
+              <EventIcon sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                No events found
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                There are no events at this time.
+              </Typography>
+            </Paper>
+          </Grid>
+        )}
+      </Grid>
+    </Container>
+  );
+}

--- a/app/player-rating-info/page.tsx
+++ b/app/player-rating-info/page.tsx
@@ -1,0 +1,2 @@
+'use client';
+export { default } from '../ratings-info/page';

--- a/app/ranking-info/page.tsx
+++ b/app/ranking-info/page.tsx
@@ -1,0 +1,2 @@
+'use client';
+export { default } from '../ratings-info/page';

--- a/app/submit-results/page.tsx
+++ b/app/submit-results/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Box,
+  Alert,
+} from '@mui/material';
+
+export default function SubmitResultsPage() {
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold', mb: 3 }}>
+        Submit Event Results
+      </Typography>
+      {submitted ? (
+        <Alert severity="success" sx={{ mb: 3 }}>
+          Results submitted! We'll review them shortly.
+        </Alert>
+      ) : (
+        <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField label="Event ID" name="event" required />
+          <TextField label="Team" name="team" required />
+          <TextField label="Placement" name="placement" type="number" required />
+          <Button type="submit" variant="contained">Submit</Button>
+        </Box>
+      )}
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 4 }}>
+        For large result submissions, email us at{' '}
+        <Link href="mailto:results@upachampionships.gg">results@upachampionships.gg</Link>.
+      </Typography>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- create new Next.js page for events listing
- add simple Submit Results form in Next.js
- alias ranking-info and player-rating-info to ratings-info page

## Testing
- `npm install`
- `NEXT_DISABLE_FONT_DOWNLOADS=1 npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_687e1812d62c832883cb96cc6ffe6ec3